### PR TITLE
Implement PWMInstance method ChangeFrequency

### DIFF
--- a/RPi/GPIO.py
+++ b/RPi/GPIO.py
@@ -204,6 +204,10 @@ class PWMInstance:
         self.duty_cycle = duty_cycle
         lgpio.tx_pwm(chip, self.gpio, self.frequency, duty_cycle)
 
+    def ChangeFrequency(self, frequency):
+        self.frequency = frequency
+        lgpio.tx_pwm(chip, self.gpio, frequency, self.duty_cycle)
+
     def stop(self):
         lgpio.tx_pwm(chip, self.gpio, 0, 0)
 


### PR DESCRIPTION
Implements method `PWMInstance.ChangeFrequency` from RPi.GPIO API (see official [example](https://sourceforge.net/p/raspberry-gpio-python/wiki/PWM/)) in the same way as `ChangeDutyCycle` is implemented.

This change allowed me to use this converter with https://github.com/KitronikLtd/Kitronik-Raspberry-Pi-Air-Quality-Control-HAT-Python