### PR TITLE
bugfix: setup function needs to be able to accept lists of pins as input

### DIFF
--- a/RPi/GPIO.py
+++ b/RPi/GPIO.py
@@ -103,21 +103,33 @@ def setwarnings(boolean=True):
     return
 
 # Setup GPIO line for INPUT or OUTPUT and set internal Pull Up/Down resistors
-def setup(gpio,mode=OUT,pull_up_down=PUD_OFF):
-    gpio = _get_gpio(gpio)
-    if mode == IN:
-        # Set up pull up/down resistors
-        if pull_up_down == PUD_UP:
-            pullupdown = LGPIO_PULL_UP
-        elif pull_up_down == PUD_DOWN:
-            pullupdown = LGPIO_PULL_DOWN
-        elif pull_up_down == PUD_OFF:
-            pullupdown = LGPIO_PULL_OFF
-        lgpio.gpio_claim_input(chip,gpio,pullupdown)
+def setup(pin_id,mode=OUT,pull_up_down=PUD_OFF,initial=LOW):
+    if type(pin_id) == int:
+        pin_count = 1
+    elif type(pin_id) == list:
+        pin_count = len(pin_id)
+    for i in range(pin_count):
+        if type(pin_id) == int:
+            gpio = _get_gpio(pin_id)
+        elif type(pin_id) == list:
+            gpio = _get_gpio(pin_id[i])
+        if mode == IN:
+            # Set up pull up/down resistors
+            if pull_up_down == PUD_UP:
+                pullupdown = LGPIO_PULL_UP
+            elif pull_up_down == PUD_DOWN:
+                pullupdown = LGPIO_PULL_DOWN
+            elif pull_up_down == PUD_OFF:
+                pullupdown = LGPIO_PULL_OFF
+            lgpio.gpio_claim_input(chip,gpio,pullupdown)
 
-    elif mode == OUT:
-        lgpio.gpio_claim_output(chip, gpio)
-
+        elif mode == OUT:
+            if initial == None:
+                lgpio.gpio_claim_output(chip, gpio)
+            elif initial == LOW:
+                lgpio.gpio_claim_output(chip, gpio, level=0)
+            elif initial == HIGH:
+                lgpio.gpio_claim_output(chip, gpio, level=1)
 # Convert LGPIO event to a GPIO event and call user callback
 # Level values (Not used by our callback but could be)
 # 0: change to low (a falling edge)


### PR DESCRIPTION
GPIO.setup optionally accepts lists of pins as input instead of an integer, which was causing my attempt to apply the converter to https://github.com/pimironi/grow-python:

`Feb 25 22:27:20 raspberrypi python[4915]: Traceback (most recent call last):
Feb 25 22:27:20 raspberrypi python[4915]:   File "/usr/bin/grow-monitor", line 1158, in <module>
Feb 25 22:27:20 raspberrypi python[4915]:     main()
Feb 25 22:27:20 raspberrypi python[4915]:   File "/usr/bin/grow-monitor", line 1052, in main
Feb 25 22:27:20 raspberrypi python[4915]:     GPIO.setup(BUTTONS, GPIO.IN, pull_up_down=GPIO.PUD_UP)
Feb 25 22:27:20 raspberrypi python[4915]:   File "/home/jlb/.virtualenvs/pimoroni/lib/python3.11/site-packages/RPi/GPIO.py", line 116, in setup
Feb 25 22:27:20 raspberrypi python[4915]:     lgpio.gpio_claim_input(chip,gpio,pullupdown)
Feb 25 22:27:20 raspberrypi python[4915]:   File "/usr/lib/python3/dist-packages/lgpio.py", line 755, in gpio_claim_input
Feb 25 22:27:20 raspberrypi python[4915]:     return _u2i(_lgpio._gpio_claim_input(handle&0xffff, lFlags, gpio))
Feb 25 22:27:20 raspberrypi python[4915]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Feb 25 22:27:20 raspberrypi python[4915]: TypeError: in method '_gpio_claim_input', argument 3 of type 'int'
`

I've done a fix to the converter's setup function so it checks the type of the first parameter and iterates through the list if a list is present. It's a bit quick-and-dirty but it let me get the pimironi code running.